### PR TITLE
Add SSL support to email notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,6 @@ You can add more options to the config.json if you need:
 
 - `"crawler_interval": 8`    // overriding default periodic callback timeout in seconds (10 by default, should be more than 7.2)
 - `"use_starttls": true` // forcing encrypted SMTP session using TLS (true by default)
+- `"use_ssl": false` // forcing encrypted SMTP session using SSL (false by default)
 - `"from_user": "sender@domain.com"`  // if smtp user is different from `from_email`
 - `"from_smtp_port": 587` // if you have non-standard (587) smtp port

--- a/notifiers/email_notifier.py
+++ b/notifiers/email_notifier.py
@@ -15,6 +15,7 @@ class EmailNotifier(Notifier):
     def __init__(self, config):
         """Override init to make SMTP-settings check"""
         self.use_starttls = config.get('use_starttls', True)
+        self.use_ssl = config.get('use_ssl', False)
         self.fromaddr = config['from_email']
         # smtp user may be different from email
         self.fromuser = config.get('from_user', self.fromaddr).encode('utf-8')
@@ -27,7 +28,10 @@ class EmailNotifier(Notifier):
 
     def check_requirements(self):
         """Logs in to SMTP server to check credentials and settings"""
-        server = smtplib.SMTP(self.host, self.port)
+        if self.use_ssl:
+            server = smtplib.SMTP_SSL(self.host, self.port)
+        else:
+            server = smtplib.SMTP(self.host, self.port)
         server.ehlo()
         if self.use_starttls:
             server.starttls()
@@ -50,7 +54,10 @@ class EmailNotifier(Notifier):
         msg['Subject'] = title
         body = text + '\nURL: ' + url
         msg.attach(MIMEText(body, 'plain'))
-        server = smtplib.SMTP(self.host, self.port)
+        if self.use_ssl:
+            server = smtplib.SMTP_SSL(self.host, self.port)
+        else:
+            server = smtplib.SMTP(self.host, self.port)
         server.ehlo()
         if self.use_starttls:
             server.starttls()


### PR DESCRIPTION
This uses the `SMTP_SSL` module from `smtplib` to handle SMTP connexions over SSL.

To use a SSL connexion for SMTP use the following config parameters:
```
"use_ssl": true,
"use_starttls": false,
"from_smtp_port": 465,
...
```