### PR TITLE
Added request timeout

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,5 +5,6 @@
     "from_email": "sender@domain.com",
     "from_pwd": "sender-password",
     "from_smtp_host": "smtp.gmail.com",
-    "to_email": "mymail@domain.com"
+    "to_email": "mymail@domain.com",
+    "crawler_interval": 30
 }

--- a/config.json.example
+++ b/config.json.example
@@ -6,5 +6,6 @@
     "from_pwd": "sender-password",
     "from_smtp_host": "smtp.gmail.com",
     "to_email": "mymail@domain.com",
-    "crawler_interval": 30
+    "crawler_interval": 30,
+    "request_timeout": 30
 }

--- a/crawler.py
+++ b/crawler.py
@@ -77,12 +77,16 @@ class Crawler(object):
         http_client = AsyncHTTPClient()
         # request OVH availability API asynchronously
         try:
-            response = yield http_client.fetch(self.API_URL, request_timeout=30)
+            response = yield http_client.fetch(self.API_URL, request_timeout=REQUEST_TIMEOUT)
         except HTTPError as ex:
             # Internal Server Error
             self.HTTP_ERRORS.append(ex)
             if len(self.HTTP_ERRORS) > 3:
                 _logger.error("Too many HTTP Errors: %s", self.HTTP_ERRORS)
+            return
+        except Exception as gex:
+            # Also catch other errors.
+            _logger.error("Socket Error: %s", str(gex))
             return
         if self.HTTP_ERRORS:
             del self.HTTP_ERRORS[:]
@@ -154,6 +158,9 @@ if __name__ == "__main__":
         if state in TRACKED_STATES:
             _logger.info("Will notify: %s", state)
             NOTIFIER.notify(**message)
+
+    # Check and set request timeout
+    REQUEST_TIMEOUT = _CONFIG.get('request_timeout', 30)
 
     # Check and set periodic callback time
     CALLBACK_TIME = _CONFIG.get('crawler_interval', 30)

--- a/crawler.py
+++ b/crawler.py
@@ -71,14 +71,13 @@ class Crawler(object):
         # save the new value
         self.STATES[state] = value
 
-
     @coroutine
     def run(self):
         """Run a crawler iteration"""
         http_client = AsyncHTTPClient()
         # request OVH availability API asynchronously
         try:
-            response = yield http_client.fetch(self.API_URL)
+            response = yield http_client.fetch(self.API_URL, request_timeout=30)
         except HTTPError as ex:
             # Internal Server Error
             self.HTTP_ERRORS.append(ex)
@@ -113,6 +112,7 @@ class Crawler(object):
                     'url': "http://www.kimsufi.com/en/index.xml"
                 }
                 self.update_state(state_id, server_available, message)
+
 
 if __name__ == "__main__":
     # load user config
@@ -156,7 +156,7 @@ if __name__ == "__main__":
             NOTIFIER.notify(**message)
 
     # Check and set periodic callback time
-    CALLBACK_TIME = _CONFIG.get('crawler_interval', 10)
+    CALLBACK_TIME = _CONFIG.get('crawler_interval', 30)
     if CALLBACK_TIME < 7.2:
         _logger.warning("Selected crawler interval of %s seconds is less than "
                         "7.2, client may be rate-limited by OVH", CALLBACK_TIME)
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 
     # start the IOloop
     LOOP = tornado.ioloop.IOLoop.instance()
-    tornado.ioloop.PeriodicCallback(crawler.run, CALLBACK_TIME*1000).start()
+    tornado.ioloop.PeriodicCallback(crawler.run, CALLBACK_TIME * 1000).start()
     _logger.info("Starting IO loop")
     try:
         LOOP.start()


### PR DESCRIPTION
Added request timeout of 30 seconds because of timeout spam (most requests take about 15 seconds for me (from EU), so the current 10 is on the very low side. Thus 30 seconds to be safe :wink: ).
Increased interval to check for availability from 10 to 30 seconds (have been getting some connection refused as well :disappointed: )
15 + 30 still checks more than once a minute, that's more than plenty in my opinion.

Let me know if I did it right :smile: (not 100% sure about the config).