### PR TITLE
Send SYS URL for SYS Servers.

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -115,6 +115,8 @@ class Crawler(object):
                         server=server_type, region=region.capitalize()),
                     'url': "http://www.kimsufi.com/en/index.xml"
                 }
+                if 'sys' in item['reference'] or 'bk' in item['reference']:
+                    message['url'] = 'http://www.soyoustart.com/de/essential-server/'
                 self.update_state(state_id, server_available, message)
 
 


### PR DESCRIPTION
If product id named "sys" or "bk", return SoYouStart URL instead of kimsufi URL.