### PR TITLE
Fixed README.md - pip warning for pre-release packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Set it up
   - `pushbullet_apikey`: your Pushbullet API key, notification sent to all devices.
 
 - Crawler runs on Python 2.7+ and Tornado framework 4.0+. Assuming that you already have Python/pip, just get Tornado and the notifier dependencies with `sudo pip install -r requirements.txt`. You can also set up virtualenv if you like.
+- If your pip install command does not complete due to xmpppy being on pre-release version (eg. 0.5.0rc1) use: `sudo pip install --pre -r requirements.txt`
 - Run with `python crawler.py`
 - It's a good idea to register an account on Kimsufi/OVH in advance; just pick any available server on www.kimsufi.com and sign up without paying. This way later you will only need to log in and enter payment details, which saves a lot of time.
 - Get and enjoy awesome cheap servers!


### PR DESCRIPTION
I noticed that with newer pip version the default installation won't go easily due to
pip not allowing xmpppy package to be installed in rc1 pre-release version.
Updated README.md to warn about that and specify a correct pip command.

Edit: Made v2 patch with prettier look.